### PR TITLE
Add IndoNLU to language model section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 1. [Leipzig corpora collection](https://corpora.uni-leipzig.de/en?corpusId=ind_mixed_2013). Indonesian mixed corpus
    based on material from 2013. Sentences: 74,329,815 - Types: 7,964,109 - Tokens: 1,206,281,985. From news materials, randomly chosen websites, and Wikipedia dumps.
 1. [CC-100](http://data.statmt.org/cc-100/). This large corpus contains articles from many sources crawled by [CommonCrawl](https://commoncrawl.org/) and extracted by [FAIR](https://github.com/facebookresearch). For Bahasa Indonesia, in total there are around 4.8B sentences and 6B sentence piece tokens. See [here](https://www.aclweb.org/anthology/2020.lrec-1.494.pdf) for more info and citations.
+1. [IndoNLU Benchmark](https://www.indobenchmark.com/) A collective effort made by researchers and practitioners from Gojek, Institut Teknologi Bandung, HKUST, Universitas Multimedia Nusantara, Prosa.ai, and Universitas Indonesia.
+They provide pre-trained BERT/ALBERT [language models](https://huggingface.co/indobenchmark)
+that were trained on a large [corpus](https://storage.googleapis.com/babert-pretraining/IndoNLU_finals/dataset/preprocessed/dataset_all_uncased_blankline.txt.xz) of 4B words (250M sentences). They also create single-sentence and sentence-pair [datasets](https://github.com/indobenchmark/indonlu) for evaluating classification and sequence-tagging tasks.
 
 ## POS tagging
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@
 
 1. [frankydotid/Indonesian-Speech-Recognition](https://github.com/frankydotid/Indonesian-Speech-Recognition).
    A small corpus of 50 utterances by a single male speaker.
+
+1. [CMU Wilderness Multilingual Speech Dataset](https://github.com/festvox/datasets-CMU_Wilderness).
+   A dataset of over 700 different languages providing audio, aligned text and word pronunciations. One of the language is Indonesian. The utterance is read from bible, which is recorded by [bible.is](bible.is)


### PR DESCRIPTION
Recently a group of researchers and practitioners released IndoNLU, which consist of pre-trained BERT LMs, corpus, and datasets.